### PR TITLE
Replace try with conditional path exists

### DIFF
--- a/parsec.py
+++ b/parsec.py
@@ -33,16 +33,14 @@ def save_index(year, qtr, index):
 
 def load_index(year, qtr):
     filename = 'index-' + str(year) + 'q' + str(qtr) + '.json'
-
-    try:
-        with open(get_path() + 'index/' + filename, 'r') as file:
-            index = json.load(file)
-            return index
-
-    except FileNotFoundError:
+    if os.path.exists(os.path.join(get_path(), 'index', filename)):
+        with open(os.path.join(get_path(), 'index', filename)) as file:
+            return json.load(file)
+    else:
         index = parse_index(get_index(year, qtr))
         save_index(year, qtr, index)
         return index
+
 
 
 


### PR DESCRIPTION
When running your code for the first time (python 3.9) the error that is produced is a read error on json.load. This error gets swallowed by your FileNotFound exception causing this code to fail on initial runs. Consider the conditional above to check to see if the file exists and if it does not then create it. 

This is awesome work, stick with it. I have some additional "triggers" or tags I have mapped and will add that shortly.